### PR TITLE
Fixed Flask and Gunicorn application

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ PYTHON_FILES := $(shell find ./* -type f -name "*.py" -print)
 PYTHON_VERSION := 3.7.4
 SYSTEM_PYTHON_CMD := $(shell ./getPythonCmd.sh ${PYTHON_VERSION} ${PYTHON_LOCAL_DIR})
 
+# default configuration
+HTTP_PORT ?= 8080
+
 # Commands
 PYTHON_CMD := $(INSTALL_DIR)/bin/python3
 PIP_CMD := $(INSTALL_DIR)/bin/pip3
@@ -42,17 +45,17 @@ help:
 	@echo
 	@echo "Possible targets:"
 	@echo -e " \033[1mBUILD TARGETS\033[0m "
-	@echo "- setup			Create the python virtual environment"
+	@echo "- setup              Create the python virtual environment"
 	@echo -e " \033[1mLINTING TOOLS TARGETS\033[0m "
-	@echo "- lint			Lint the python source code"
+	@echo "- lint               Lint and format the python source code"
 	@echo -e " \033[1mLOCAL SERVER TARGETS\033[0m "
-	@echo "- serve			Run the project using the flask debug server"
-	@echo "- gunicornserve		Run the project using the gunicorn WSGI server"
-	@echo "- dockerrun		Run the project using the gunicorn WSGI server inside a container. Env variable HTTP_PORT should be set"
-	@echo "- shutdown		Stop the aforementioned container"
+	@echo "- serve              Run the project using the flask debug server. Port can be set by Env variable HTTP_PORT (default: 8080)"
+	@echo "- gunicornserve      Run the project using the gunicorn WSGI server. Port can be set by Env variable HTTP_PORT (default: 8080)"
+	@echo "- dockerrun          Run the project using the gunicorn WSGI server inside a container (port: 8080)"
+	@echo "- shutdown           Stop the aforementioned container"
 	@echo -e " \033[1mCLEANING TARGETS\033[0m "
-	@echo "- clean			Clean genereated files"
-	@echo "- clean_venv		Clean python venv"
+	@echo "- clean              Clean genereated files"
+	@echo "- clean_venv         Clean python venv"
 
 # Build targets. Calling setup is all that is needed for the local files to be installed as needed. Bundesnetz may cause problem.
 
@@ -84,11 +87,11 @@ lint: .venv/build.timestamp
 # Serve targets. Using these will run the application on your local machine. You can either serve with a wsgi front (like it would be within the container), or without.
 .PHONY: serve
 serve: .venv/build.timestamp
-	FLASK_APP=service_launcher FLASK_DEBUG=1 ${FLASK_CMD} run --host=0.0.0.0 --port=${HTTP_PORT}
+	FLASK_APP=service_launcher FLASK_DEBUG=1 $(FLASK_CMD) run --host=0.0.0.0 --port=$(HTTP_PORT)
 
 .PHONY: gunicornserve
 gunicornserve: .venv/build.timestamp
-	${SYSTEM_PYTHON_CMD} wsgi.py
+	${PYTHON_CMD} wsgi.py
 
 # Docker related functions.
 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ PYTHON_CMD := $(INSTALL_DIR)/bin/python3
 PIP_CMD := $(INSTALL_DIR)/bin/pip3
 FLASK_CMD := $(INSTALL_DIR)/bin/flask
 YAPF_CMD := $(INSTALL_DIR)/bin/yapf
+NOSE_CMD := $(INSTALL_DIR)/bin/nose2
 all: help
 
 # This bit check define the build/python "target": if the system has an acceptable version of python, there will be no need to install python locally.
@@ -48,6 +49,7 @@ help:
 	@echo "- setup              Create the python virtual environment"
 	@echo -e " \033[1mLINTING TOOLS TARGETS\033[0m "
 	@echo "- lint               Lint and format the python source code"
+	@echo "- test               Run the tests"
 	@echo -e " \033[1mLOCAL SERVER TARGETS\033[0m "
 	@echo "- serve              Run the project using the flask debug server. Port can be set by Env variable HTTP_PORT (default: 8080)"
 	@echo "- gunicornserve      Run the project using the gunicorn WSGI server. Port can be set by Env variable HTTP_PORT (default: 8080)"
@@ -83,6 +85,10 @@ $(PYTHON_LOCAL_DIR)/bin/python3.7:
 .PHONY: lint
 lint: .venv/build.timestamp
 	$(YAPF_CMD) -i --style .style.yapf $(PYTHON_FILES)
+
+.PHONY: test
+test: .venv/build.timestamp
+	$(NOSE_CMD) -s tests/
 
 # Serve targets. Using these will run the application on your local machine. You can either serve with a wsgi front (like it would be within the container), or without.
 .PHONY: serve

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,10 +1,10 @@
 from flask import Flask
-from app.middleware import ReverseProxied
+from app.middleware import ReverseProxies
 
 # Standard Flask application initialisation
 
 app = Flask(__name__)
-app.wsgi_app = ReverseProxied(app.wsgi_app, script_name='/')
+app.wsgi_app = ReverseProxies(app.wsgi_app, script_name='/')
 
 
 from app import routes

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,10 +1,10 @@
 from flask import Flask
-from app.middleware import ReverseProxies
+from app.middleware import ReverseProxy
 
 # Standard Flask application initialisation
 
 app = Flask(__name__)
-app.wsgi_app = ReverseProxies(app.wsgi_app, script_name='/')
+app.wsgi_app = ReverseProxy(app.wsgi_app, script_name='/')
 
 
 from app import routes
@@ -16,7 +16,7 @@ def main():
 
 if __name__ == '__main__':
     """
-    Entrypoint for the application. At the moment, we do nothing specific, but there might be preparatory steps in the 
+    Entrypoint for the application. At the moment, we do nothing specific, but there might be preparatory steps in the
     future
     """
     main()

--- a/app/middleware.py
+++ b/app/middleware.py
@@ -1,4 +1,4 @@
-class ReverseProxied(object):
+class ReverseProxies(object):
     """
     Reverse proxies can cause some problems within applications, as they change routes, redirect traffic, and
     applications might have errors because of that. This piece of middlewar make sure everything runs smoothly.

--- a/app/middleware.py
+++ b/app/middleware.py
@@ -1,4 +1,4 @@
-class ReverseProxies(object):
+class ReverseProxy(object):
     """
     Reverse proxies can cause some problems within applications, as they change routes, redirect traffic, and
     applications might have errors because of that. This piece of middlewar make sure everything runs smoothly.
@@ -22,12 +22,12 @@ class ReverseProxies(object):
         """
 
         """
-        The first part makes sure the route goes to the right resource. 
-        If we have a query made to reverse-proxy.admin.ch/generic_name/generate, 
+        The first part makes sure the route goes to the right resource.
+        If we have a query made to reverse-proxy.admin.ch/generic_name/generate,
         HTTP_X_SCRIPT_NAME will be /generic_name, and PATH_INFO would be /generic_name/generate.
-        
+
         PATH_INFO is used to handle the route called (in this case, it would use /generate)
-        SCRIPT_NAME is used to prefix the routes so that the application returns a correct answer (namely: that the 
+        SCRIPT_NAME is used to prefix the routes so that the application returns a correct answer (namely: that the
         query was hitting /generic_name/generate).
         """
         # The syntax here means : try to get HTTP_X_SCRIPT_NAME, or get me an empty string, and the command or, in the

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,6 @@
+from app import app
+
+
+@app.route('/check/')
+def check():
+    return "Success"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+gevent==20.6.2
 gunicorn==19.9.0
 flask==1.1.1

--- a/wsgi.py
+++ b/wsgi.py
@@ -23,7 +23,7 @@ class StandaloneApplication(BaseApplication):
 
 # We use the port 8080 as default, otherwise we set the HTTP_PORT env variable within the container.
 if __name__ == '__main__':
-    HTTP_PORT = str(os.environ.get('HTTP_PORT'), "8080")
+    HTTP_PORT = str(os.environ.get('HTTP_PORT', "8080"))
     # Bind to 0.0.0.0 to let your app listen to all network interfaces.
     options = {
         'bind': '%s:%s' % ('0.0.0.0', HTTP_PORT),


### PR DESCRIPTION
The application could not be started neither from Flask or from
    Gunicorn.
    
    - gevent was missing from requirements and is required for the gunicorn
    worker
    - middleware renaming from ReverseProxied to ReverseProxies was not done
    every where
    - Default port for Flask was missing in MakeFile
    - The system python command was used instead of the virtualenv python
    commmand for starting gunicorn
    - wsgi.py had a typo for the HTTP port definition
    - Updated the MakeFile help