### PR TITLE
Changed default dev port from 8080 to 5000 and fixed codebuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SYSTEM_PYTHON_CMD := $(shell ./getPythonCmd.sh ${PYTHON_VERSION} ${PYTHON_LOCAL_
 LOCAL_PYTHON_CMD := $(PYTHON_LOCAL_DIR)/bin/python$(PYTHON_MAJOR_MINOR_VERSION)
 
 # default configuration
-HTTP_PORT ?= 8080
+HTTP_PORT ?= 5000
 
 # Commands
 PYTHON_CMD := $(INSTALL_DIR)/bin/python3
@@ -55,8 +55,8 @@ help:
 	@echo "- lint               Lint and format the python source code"
 	@echo "- test               Run the tests"
 	@echo -e " \033[1mLOCAL SERVER TARGETS\033[0m "
-	@echo "- serve              Run the project using the flask debug server. Port can be set by Env variable HTTP_PORT (default: 8080)"
-	@echo "- gunicornserve      Run the project using the gunicorn WSGI server. Port can be set by Env variable HTTP_PORT (default: 8080)"
+	@echo "- serve              Run the project using the flask debug server. Port can be set by Env variable HTTP_PORT (default: 5000)"
+	@echo "- gunicornserve      Run the project using the gunicorn WSGI server. Port can be set by Env variable HTTP_PORT (default: 5000)"
 	@echo "- dockerrun          Run the project using the gunicorn WSGI server inside a container (port: 8080)"
 	@echo "- shutdown           Stop the aforementioned container"
 	@echo -e " \033[1mCLEANING TARGETS\033[0m "

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -18,11 +18,11 @@ phases:
       - echo "Installing necessary softwares"
       - docker login -u ${CI_DOCKERHUB_USER} -p ${CI_DOCKERHUB_PASSWORD}
       - apt-get update && apt-get install -y docker-compose python3-pip
-      - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
-      - GITHUB_BRANCH=${CODEBUILD_WEBHOOK_HEAD_REF#refs/heads/*}
   pre_build:
     commands:
       - echo "export of the image tag for build and push purposes"
+      - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
+      - GITHUB_BRANCH=${CODEBUILD_WEBHOOK_HEAD_REF#refs/heads/*}
       - export IMAGE_TAG="${GITHUB_BRANCH}.${COMMIT_HASH}"
       - echo "creating a clean environment"
       - make clean setup

--- a/wsgi.py
+++ b/wsgi.py
@@ -24,7 +24,7 @@ class StandaloneApplication(BaseApplication):  # pylint: disable=abstract-method
 
 # We use the port 8080 as default, otherwise we set the HTTP_PORT env variable within the container.
 if __name__ == '__main__':
-    HTTP_PORT = str(os.environ.get('HTTP_PORT', "8080"))
+    HTTP_PORT = str(os.environ.get('HTTP_PORT', "5000"))
     # Bind to 0.0.0.0 to let your app listen to all network interfaces.
     options = {
         'bind': '%s:%s' % ('0.0.0.0', HTTP_PORT),


### PR DESCRIPTION
The default port 8080 is already used by the proxy on the developer
machine therefore change it to 5000 (flask default).

AWS codebuild failed because the variable
CODEBUILD_RESOLVED_SOURCE_VERSION and CODEBUILD_WEBHOOK_HEAD_REF were
not yet ready in the install phase, because these variables are only
needed later, simply moved them in the pre_build phase.