### PR TITLE
BGDIINF_SB-1181: Fixed codebuild docker error in auto and manual build

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -18,11 +18,13 @@ phases:
       - echo "Installing necessary softwares"
       - docker login -u ${CI_DOCKERHUB_USER} -p ${CI_DOCKERHUB_PASSWORD}
       - apt-get update && apt-get install -y docker-compose python3-pip
-      - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
-      - GITHUB_BRANCH=${CODEBUILD_WEBHOOK_HEAD_REF#refs/heads/*}
   pre_build:
     commands:
       - echo "export of the image tag for build and push purposes"
+      - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
+      - GITHUB_BRANCH=${CODEBUILD_WEBHOOK_HEAD_REF#refs/heads/*}
+      # Manual build don't have the CODEBUILD_WEBHOOK_HEAD_REF variable set, therefore use the source version set during the manual build
+      - GITHUB_BRANCH=${GITHUB_BRANCH:-${CODEBUILD_SOURCE_VERSION}}
       - export IMAGE_TAG="${GITHUB_BRANCH}.${COMMIT_HASH}"
       - echo "creating a clean environment"
       - make clean setup


### PR DESCRIPTION

The `CODE_BUILD_` variables are not yet available in `install` phase,
this result to an invalid docker tag and the docker build failed.

In manual build triggered from codebuild, the var `CODEBUILD_WEBHOOK_`
is not set which also resulted to an invalid docker tag.