### PR TITLE
BGDIINF_SB-1261: Fixed dockerrun target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,8 @@ help:
 	@echo -e " \033[1mLOCAL SERVER TARGETS\033[0m "
 	@echo "- serve              Run the project using the flask debug server. Port can be set by Env variable HTTP_PORT (default: 5000)"
 	@echo "- gunicornserve      Run the project using the gunicorn WSGI server. Port can be set by Env variable HTTP_PORT (default: 5000)"
-	@echo "- dockerrun          Run the project using the gunicorn WSGI server inside a container (port: 8080)"
+	@echo "- dockerbuild        Build the project localy using the gunicorn WSGI server inside a container"
+	@echo "- dockerrun          Run the project using the gunicorn WSGI server inside a container (exposed port: 5000)"
 	@echo "- shutdown           Stop the aforementioned container"
 	@echo -e " \033[1mCLEANING TARGETS\033[0m "
 	@echo "- clean              Clean genereated files"
@@ -108,13 +109,20 @@ gunicornserve: .venv/build.timestamp
 
 # Docker related functions.
 
+.PHONY: dockerbuild
+dockerbuild:
+	docker build -t swisstopo/service-qrcode:local .
+
+export-http-port:
+	@export HTTP_PORT=$(HTTP_PORT)
+
 .PHONY: dockerrun
-dockerrun:
+dockerrun: export-http-port
 	docker-compose up -d;
 	sleep 10
 
 .PHONY: shutdown
-shutdown:
+shutdown: export-http-port
 	docker-compose down
 
 # Cleaning functions. clean_venv will only remove the virtual environment, while clean will also remove the local python installation.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
-version: '2'
+version: "2"
 services:
   app:
     image: swisstopo/service-name:local
     ports:
-      - '8080:8080'
+      - "${HTTP_PORT}:8080"


### PR DESCRIPTION

The dockerrun make target was done to run a local docker image on port
8080. The port 8080 is already used by the BIT proxy on the developper
machines and there were not target for building a local image.

Now there is a target to build local image that can be started by
dockerrun.

The default exported port by the local docker image is 5000 and can be
changed by an environment variable. This variable needs to be set prior
to deployment in order to use another port, but as deployment will be
automated it is not an issue to have to  set an environment variable
before it.