### PR TITLE
Updated README for AWS ECR and corrected makefile for dockerrun

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,8 +78,7 @@ help:
 	@echo "- dockerlogin        Login to the AWS ECR registery for pulling/pushing docker images"
 	@echo "- dockerbuild        Build the project localy (with tag := $(DOCKER_IMG_LOCAL_TAG)) using the gunicorn WSGI server inside a container"
 	@echo "- dockerpush         Build and push the project localy (with tag := $(DOCKER_IMG_LOCAL_TAG))"
-	@echo "- dockerrun          Run the project using the gunicorn WSGI server inside a container (exposed port: 5000)"
-	@echo "- shutdown           Stop the aforementioned container"
+	@echo "- dockerrun          Run the project using the gunicorn WSGI server inside a container (exposed port: $(HTTP_PORT))"
 	@echo -e " \033[1mCLEANING TARGETS\033[0m "
 	@echo "- clean              Clean genereated files"
 	@echo "- clean_venv         Clean python venv"
@@ -174,12 +173,8 @@ dockerpush: dockerbuild
 
 .PHONY: dockerrun
 dockerrun: dockerbuild
-	HTTP_PORT=$(HTTP_PORT) docker-compose up
-
-
-.PHONY: shutdown
-shutdown:
-	HTTP_PORT=$(HTTP_PORT) SERVICE_NAME=$(SERVICE_NAME) docker-compose down
+	echo "Starting docker container and mapped its 8080 port to $(HTTP_PORT); http://localhost:$(HTTP_PORT)"
+	docker run -it -p $(HTTP_PORT):8080 $(DOCKER_IMG_LOCAL_TAG)
 
 
 # Spec targets

--- a/README.md
+++ b/README.md
@@ -48,40 +48,70 @@ The **Make** targets assume you have **python3.7**, **pipenv**, **bash**, **curl
 ### Setting up to work
 
 First, you'll need to clone the repo
-    git clone git@github.com:geoadmin/service-name
+
+```bash
+git clone git@github.com:geoadmin/service-name
+```
+
 Then, you can run the setup target to ensure you have everything needed to develop, test and serve locally
-    make setup
+
+```bash
+make setup
+```
+
 That's it, you're ready to work.
+
 ### Linting and formatting your work
+
 In order to have a consistent code style the code should be formatted using `yapf`. Also to avoid syntax errors and non
 pythonic idioms code, the project uses the `pylint` linter. Both formatting and linter can be manually run using the
 following command:
-    make format-lint
+
+```bash
+make format-lint
+```
+
 **Formatting and linting should be at best integrated inside the IDE, for this look at
 [Integrate yapf and pylint into IDE](https://github.com/geoadmin/doc-guidelines/blob/master/PYTHON.md#yapf-and-pylint-ide-integration)**
+
 ### Test your work
+
 Testing if what you developed work is made simple. You have four targets at your disposal. **test, serve, gunicornserve, dockerrun**
-    make test
+
+```bash
+make test
+```
+
 This command run the integration and unit tests.
-    make serve
+
+```bash
+make serve
+```
+
 This will serve the application through Flask without any wsgi in front.
 
-    make gunicornserve
+```bash
+make gunicornserve
+```
 
 This will serve the application with the Gunicorn layer in front of the application
 
-    make dockerrun
+```bash
+make dockerrun
+```
 
 This will serve the application with the wsgi server, inside a container.
 To stop serving through containers,
 
-    make shutdown
+```bash
+make shutdown
+```
 
 Is the command you're looking for.
 
 ## Docker
 
-The service is encapsulated in a Docker image. Images are pushed on the public [Dockerhub](https://hub.docker.com/r/swisstopo/service-name/tags) registry. From each github PR that is merged into develop branch, one Docker image is built and pushed with the following tags:
+The service is encapsulated in a Docker image. Images are pushed on the `swisstopo-bgdi-builder` account of [AWS ECR](https://eu-central-1.console.aws.amazon.com/ecr/repositories?region=eu-central-1) registry. From each github PR that is merged into develop branch, one Docker image is built and pushed with the following tags:
 
 - `develop.latest`
 - `CURRENT_VERSION-beta.INCREMENTAL_NUMBER`
@@ -103,7 +133,7 @@ These metadata can be seen directly on the dockerhub registry in the image layer
 ```bash
 # NOTE: jq is only used for pretty printing the json output,
 # you can install it with `apt install jq` or simply enter the command without it
-docker image inspect --format='{{json .Config.Labels}}' swisstopo/service-name:develop.latest | jq
+docker image inspect --format='{{json .Config.Labels}}' 974517877189.dkr.ecr.eu-central-1.amazonaws.com/service-name:develop.latest | jq
 ```
 
 You can also check these metadata on a running container as follows
@@ -116,6 +146,7 @@ docker ps --format="table {{.ID}}\t{{.Image}}\t{{.Labels}}"
 
 This service is to be deployed to the Kubernetes cluster once it is merged.
 TO DO: give instructions to deploy to kubernetes.
+
 ### Deployment configuration
 
 The service is configured by Environment Variable:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,0 @@
-version: "2"
-services:
-  app:
-    image: "swisstopo/${SERVICE_NAME}:local"
-    ports:
-      - "${HTTP_PORT}:8080"
-    environment:
-      - LOGGING_CFG


### PR DESCRIPTION
The dockerrun used docker-compose with still a reference to a docker
image in dockerhub. This has been simplified by using docker run instead
of docker-compose.