### PR TITLE
Fix ci-check-format target on the CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,9 +113,10 @@ format:
 
 .PHONY: ci-check-format
 ci-check-format: format
-	@if [[ -n `git status --porcelain` ]]; then \
-		>&2 echo "ERROR: the following files are not formatted correctly:"; \
-		>&2 git status --porcelain; \
+	@if [[ -n `git status --porcelain --untracked-files=no` ]]; then \
+	 	>&2 echo "ERROR: the following files are not formatted correctly"; \
+	 	>&2 echo "'git status --porcelain' reported changes in those files after a 'make format' :"; \
+		>&2 git status --porcelain --untracked-files=no; \
 		exit 1; \
 	fi
 


### PR DESCRIPTION
as it was detecting untracked file created by the CI itself, and then failing because git status was showing them (even though they are unrelated to the project)
we then only need to check tracked file changes after the formatter as done its job