### PR TITLE
Better compatibility with many shells - #minor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,5 +218,5 @@ $(TIMESTAMPS):
 
 
 $(LOGS_DIR):
-	mkdir -p -m=777 $(LOGS_DIR)
+	mkdir -p -m 777 $(LOGS_DIR)
 


### PR DESCRIPTION
I had issue with `-m=XXX` with my macOS shell, and if I remove the `=` sign it's all good, without changing what it does.