### PR TITLE
PB-1783: Update python - #minor

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,12 +4,12 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-PyYAML = "*"
-gevent = "*"
-gunicorn = "*"
-Flask = "*"
-logging-utilities = "*"
-python-dotenv = "*"
+PyYAML = "~=6.0"
+gevent = "~=21.12"
+gunicorn = "~=20.1"
+Flask = "~=2.0"
+logging-utilities = "~=1.2"
+python-dotenv = "~=0.19"
 
 [dev-packages]
 yapf = "*"
@@ -19,4 +19,4 @@ pylint-flask = "*"
 shellcheck-py = "*"
 
 [requires]
-python_version = "3.9"
+python_version = "3.13"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ See also [Git Flow - Versioning](https://github.com/geoadmin/doc-guidelines/blob
 
 ### Make Dependencies
 
-The **Make** targets assume you have **python3.9**, **pipenv**, **bash**, **curl**, **tar**, **docker** and **docker-compose** installed.
+The **Make** targets assume you have **python3.13**, **pipenv**, **bash**, **curl**, **tar**, **docker** and **docker-compose** installed.
 
 ### Setting up to work
 
@@ -92,6 +92,31 @@ make dockerrun
 ```
 
 This will serve the application with the wsgi server, inside a container.
+
+### Updating Packages
+
+All packages used in production are pinned to a major version. Automatically updating these packages
+will use the latest minor (or patch) version available. Packages used for development, on the other
+hand, are not pinned unless they need to be used with a specific version of a production package
+(for example, boto3-stubs for boto3).
+
+To update the packages to the latest minor/compatible versions, run:
+
+```bash
+pipenv update --dev
+```
+
+To see what major/incompatible releases would be available, run:
+
+```bash
+pipenv update --dev --outdated
+```
+
+To update packages to a new major release, run:
+
+```bash
+pipenv install logging-utilities~=5.0
+```
 
 ## Docker
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -12,7 +12,7 @@ env:
 phases:
   install:
     runtime-versions:
-      python: 3.9
+      python: 3.13
     commands:
       - aws --version
       - echo "Login to AWS ECR docker registry"


### PR DESCRIPTION
Updates local python version definition, package pins and package update description in the README to match that of service-stac and service-control. They base image was already updated to python 3.13. Does not update the packages.